### PR TITLE
Fix .page-title misposition

### DIFF
--- a/style.sass
+++ b/style.sass
@@ -152,8 +152,6 @@ strong
   font-size: 2em
   text-align: center
   font-weight: 500
-  margin: 0
-  margin: .5em
 
 .nonphone
   display: inline


### PR DESCRIPTION
By removing margin properties